### PR TITLE
$user->rename in the same branch fix

### DIFF
--- a/src/Models/Model.php
+++ b/src/Models/Model.php
@@ -1114,7 +1114,12 @@ abstract class Model implements ArrayAccess, JsonSerializable
         if ($moved) {
             // If the model was successfully moved, we'll set its
             // new DN so we can sync it's attributes properly.
-            $this->setDn("{$rdn},{$newParentDn}");
+            if (! empty($newParentDn)) {
+                $this->setDn("{$rdn},{$newParentDn}");
+            }
+            else {
+                $this->setDn($rdn.substr($this->getDn(), strpos($this->getDn(), ',')));
+            }
 
             $this->syncRaw();
 


### PR DESCRIPTION
In the same branch $newParentDn is null, improved patch compared to the closed one